### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: choco-pkgs test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/KarbitsCode/choco-pkgs/security/code-scanning/2](https://github.com/KarbitsCode/choco-pkgs/security/code-scanning/2)

To follow best practices and remediate the CodeQL warning, add a `permissions` block to the workflow, granting only those privileges necessary to the jobs. Since the job simply checks out code, sets up dependencies, and runs scripts (all read-only tasks), it only needs `contents: read`.  
The best place for this block is at the root (top) of the workflow, ensuring that all jobs (currently and in the future) default to minimal required permissions.  
This is accomplished by inserting the following after the `name: choco-pkgs test` line and before the `on:` line:
```yaml
permissions:
  contents: read
```
No new methods, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
